### PR TITLE
バグ

### DIFF
--- a/Test/Assets/Scripts/Bullet.cs
+++ b/Test/Assets/Scripts/Bullet.cs
@@ -249,7 +249,7 @@ namespace Scripts
             UpdatePower(); // 最終的な速度と方向でpowerを更新
     
             Time.timeScale = 1f;
-            
+            player.IsAttacking = false;
             isAttack = false;
 
             Invoke("AttackFalse", 0.2f);

--- a/Test/Assets/Scripts/Player.cs
+++ b/Test/Assets/Scripts/Player.cs
@@ -41,7 +41,7 @@ namespace Scripts
         [JapaneseLabel("ジャンプ中か")]private bool isJump;
         [JapaneseLabel("ジャンプ数")]private int jumpCount;
         [JapaneseLabel("最後にジャンプした時間")]private float lastJumpTime;
-        [JapaneseLabel("攻撃中か")]private bool IsAttacking = false;
+        [JapaneseLabel("攻撃中か")]public bool IsAttacking = false;
         [JapaneseLabel("発射中か")]private bool IsShot = false;
         [JapaneseLabel("移動中か")][NonSerialized] public bool isMove = true;
         
@@ -316,7 +316,7 @@ namespace Scripts
             if(IsAttacking) return;
             //if (currentStamina <= quickStaminaDrainPerSecond) return;
 
-            IsAttacking = true;
+            //IsAttacking = true;
             if (sceneButtonManager.currentState != SceneButtonManager.State.Gameplay) return;
             
 
@@ -333,7 +333,7 @@ namespace Scripts
         }
         public void AttackFinish()
         {
-            IsAttacking = false;
+            //IsAttacking = false;
             AttackCollision.gameObject.SetActive(false);
             QuickAttackCollision.gameObject.SetActive(false);
         }


### PR DESCRIPTION
# やったこと
- 角度反射中にクイック反射ができてしまっていたのを修正

# 作業予定

- 弾いた直後の弾がプレイヤーに当たって消える

> -> #147 が実装するかどうかで作業します

- Lスティックが常に少し傾いていて歩きモーションが出てしまう

> ->再現できないので多分コントローラー本体の問題だと思う（なった時の操作や状態を詳しく教えてほしいです）
