### PR TITLE
当たり判定の3D化

### DIFF
--- a/Test/Assets/Prefabs/Bullet.prefab
+++ b/Test/Assets/Prefabs/Bullet.prefab
@@ -9,12 +9,12 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2181899153122864126}
-  - component: {fileID: 4780306026954559086}
   - component: {fileID: 7873453308070845518}
-  - component: {fileID: -7450406237200699315}
   - component: {fileID: 3989409182975949136}
   - component: {fileID: 242804695588464806}
   - component: {fileID: -7792052319977231035}
+  - component: {fileID: 9061379316207579321}
+  - component: {fileID: 5221315896450066904}
   m_Layer: 10
   m_Name: Bullet
   m_TagString: Bullet
@@ -39,42 +39,6 @@ Transform:
   - {fileID: 7049217215620934409}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!58 &4780306026954559086
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1057501140420241128}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: 0, y: 0}
-  m_Radius: 0.5
 --- !u!114 &7873453308070845518
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -90,33 +54,6 @@ MonoBehaviour:
   meshRendererChild: {fileID: 6681353420888942644}
   characterParams: {fileID: 11400000, guid: ba6e45e6d168adb41bcb14b428391fe5, type: 2}
   trailRenderer: {fileID: 5270402208079695448}
---- !u!50 &-7450406237200699315
-Rigidbody2D:
-  serializedVersion: 5
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1057501140420241128}
-  m_BodyType: 1
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_GravityScale: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 0
 --- !u!23 &3989409182975949136
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -204,6 +141,54 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5048839d001741dab5ff90d7d89a7bbf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!135 &9061379316207579321
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1057501140420241128}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &5221315896450066904
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1057501140420241128}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!1 &5919746632611300560
 GameObject:
   m_ObjectHideFlags: 0

--- a/Test/Assets/Prefabs/Enemy/Boss/Boss.prefab
+++ b/Test/Assets/Prefabs/Enemy/Boss/Boss.prefab
@@ -193,8 +193,8 @@ GameObject:
   - component: {fileID: 1902909798016546382}
   - component: {fileID: 7850114440198246526}
   - component: {fileID: 571014512685998233}
-  - component: {fileID: 1621391100611991787}
   - component: {fileID: 3011621265069522158}
+  - component: {fileID: 2264905217055064930}
   m_Layer: 0
   m_Name: Laser
   m_TagString: Untagged
@@ -270,52 +270,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!61 &1621391100611991787
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2516122783139091720}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: -2.2737368e-13, y: 0.00000017881393}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  m_Size: {x: 1.0000006, y: 1.0000005}
-  m_EdgeRadius: 0
 --- !u!114 &3011621265069522158
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -328,6 +282,27 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ae46b7bbe6d55ea4db1596f427851d02, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!65 &2264905217055064930
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2516122783139091720}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1.0000005, y: 1.0000005, z: 1}
+  m_Center: {x: -4.2632564e-14, y: 0.00000017881393, z: 0}
 --- !u!1 &2764925282164886474
 GameObject:
   m_ObjectHideFlags: 0
@@ -339,8 +314,8 @@ GameObject:
   - component: {fileID: 999462073380326190}
   - component: {fileID: 839707299004385011}
   - component: {fileID: 1421813589501375631}
-  - component: {fileID: 1154017684893431731}
   - component: {fileID: 3075416314642452890}
+  - component: {fileID: 3538385868035666823}
   m_Layer: 0
   m_Name: Laser
   m_TagString: Untagged
@@ -416,52 +391,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!61 &1154017684893431731
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2764925282164886474}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: 0, y: 0.00000017881393}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  m_Size: {x: 1.0000006, y: 1.0000005}
-  m_EdgeRadius: 0
 --- !u!114 &3075416314642452890
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -474,6 +403,27 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ae46b7bbe6d55ea4db1596f427851d02, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!65 &3538385868035666823
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2764925282164886474}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1.0000005, y: 1.0000005, z: 1}
+  m_Center: {x: 1.4210855e-14, y: 0.00000017881393, z: 0}
 --- !u!1 &3526102378641595988
 GameObject:
   m_ObjectHideFlags: 0
@@ -1040,7 +990,7 @@ PrefabInstance:
       addedObject: {fileID: 2002568068330471627}
     - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 8651208920278cc48ac0246f4714a18c, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 2782544356136900321}
+      addedObject: {fileID: 8978435637284121190}
   m_SourcePrefab: {fileID: 100100000, guid: 8651208920278cc48ac0246f4714a18c, type: 3}
 --- !u!1 &2448015476750895501 stripped
 GameObject:
@@ -1108,6 +1058,7 @@ MonoBehaviour:
   ShotSound: {fileID: 8300000, guid: c61f9dc4363342c47ad930f260084f8d, type: 3}
   DamageSound: {fileID: 8300000, guid: cdc31c7c9b1fcb842a6f9e4e3d2fa9e3, type: 3}
   enemySpawn: {fileID: 0}
+  enemyHPSlider: {fileID: 0}
 --- !u!82 &2002568068330471627
 AudioSource:
   m_ObjectHideFlags: 0
@@ -1205,16 +1156,13 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
---- !u!58 &2782544356136900321
-CircleCollider2D:
+--- !u!135 &8978435637284121190
+SphereCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2448015476750895501}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
   m_Material: {fileID: 0}
   m_IncludeLayers:
     serializedVersion: 2
@@ -1223,24 +1171,12 @@ CircleCollider2D:
     serializedVersion: 2
     m_Bits: 0
   m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
   m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: 0, y: 0}
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
   m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!4 &3076743286398194487 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 8651208920278cc48ac0246f4714a18c, type: 3}

--- a/Test/Assets/Prefabs/Enemy/Enemy.prefab
+++ b/Test/Assets/Prefabs/Enemy/Enemy.prefab
@@ -320,9 +320,9 @@ GameObject:
   - component: {fileID: 8014104560786095915}
   - component: {fileID: 7256292872931493093}
   - component: {fileID: 5700466450639599074}
-  - component: {fileID: 2234164896924348768}
   - component: {fileID: 3317964292277821450}
-  - component: {fileID: 4151815204507809134}
+  - component: {fileID: 7523357519409778858}
+  - component: {fileID: 8768057027669054680}
   m_Layer: 8
   m_Name: Enemy
   m_TagString: Untagged
@@ -430,42 +430,7 @@ MonoBehaviour:
   ShotSound: {fileID: 8300000, guid: c61f9dc4363342c47ad930f260084f8d, type: 3}
   DamageSound: {fileID: 8300000, guid: cdc31c7c9b1fcb842a6f9e4e3d2fa9e3, type: 3}
   enemySpawn: {fileID: 0}
---- !u!58 &2234164896924348768
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6460471003761360793}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: 0, y: 0}
-  m_Radius: 0.5
+  enemyHPSlider: {fileID: 0}
 --- !u!82 &3317964292277821450
 AudioSource:
   m_ObjectHideFlags: 0
@@ -563,22 +528,13 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
---- !u!50 &4151815204507809134
-Rigidbody2D:
-  serializedVersion: 5
+--- !u!135 &7523357519409778858
+SphereCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6460471003761360793}
-  m_BodyType: 0
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_GravityScale: 0
   m_Material: {fileID: 0}
   m_IncludeLayers:
     serializedVersion: 2
@@ -586,10 +542,40 @@ Rigidbody2D:
   m_ExcludeLayers:
     serializedVersion: 2
     m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &8768057027669054680
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6460471003761360793}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 0
   m_Interpolate: 0
-  m_SleepingMode: 1
+  m_Constraints: 126
   m_CollisionDetection: 0
-  m_Constraints: 7
 --- !u!1 &6722164026637600296
 GameObject:
   m_ObjectHideFlags: 0

--- a/Test/Assets/Prefabs/Enemy/HorizontalPatrolEnemy.prefab
+++ b/Test/Assets/Prefabs/Enemy/HorizontalPatrolEnemy.prefab
@@ -13,9 +13,9 @@ GameObject:
   - component: {fileID: 7033426621156983641}
   - component: {fileID: 7217612130812051956}
   - component: {fileID: 3199154082676064227}
-  - component: {fileID: 576490511984205058}
   - component: {fileID: 8555333482593277418}
-  - component: {fileID: 2298025549173808308}
+  - component: {fileID: 7177179357133333364}
+  - component: {fileID: 4072309332046556545}
   m_Layer: 0
   m_Name: HorizontalPatrolEnemy
   m_TagString: Untagged
@@ -106,6 +106,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   patrolEnemyData: {fileID: 11400000, guid: bfcdde73abbbf8543aa60bab7ef0dfb1, type: 2}
   speed: 2
+  movement: {x: 0, y: 0}
   moveable: 0
 --- !u!114 &3199154082676064227
 MonoBehaviour:
@@ -138,42 +139,7 @@ MonoBehaviour:
   ShotSound: {fileID: 8300000, guid: c61f9dc4363342c47ad930f260084f8d, type: 3}
   DamageSound: {fileID: 8300000, guid: cdc31c7c9b1fcb842a6f9e4e3d2fa9e3, type: 3}
   enemySpawn: {fileID: 0}
---- !u!58 &576490511984205058
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3159114115912618419}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: 0, y: 0}
-  m_Radius: 0.5
+  enemyHPSlider: {fileID: 0}
 --- !u!82 &8555333482593277418
 AudioSource:
   m_ObjectHideFlags: 0
@@ -271,22 +237,13 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
---- !u!50 &2298025549173808308
-Rigidbody2D:
-  serializedVersion: 5
+--- !u!135 &7177179357133333364
+SphereCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3159114115912618419}
-  m_BodyType: 0
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_GravityScale: 0
   m_Material: {fileID: 0}
   m_IncludeLayers:
     serializedVersion: 2
@@ -294,10 +251,40 @@ Rigidbody2D:
   m_ExcludeLayers:
     serializedVersion: 2
     m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &4072309332046556545
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3159114115912618419}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 0
   m_Interpolate: 0
-  m_SleepingMode: 1
+  m_Constraints: 126
   m_CollisionDetection: 0
-  m_Constraints: 7
 --- !u!1 &3220257421039231593
 GameObject:
   m_ObjectHideFlags: 0

--- a/Test/Assets/Prefabs/Enemy/JumpEnemy Variant.prefab
+++ b/Test/Assets/Prefabs/Enemy/JumpEnemy Variant.prefab
@@ -60,6 +60,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8768057027669054680, guid: 085027a2192f29148b1e3ccdbf4f6b39, type: 3}
+      propertyPath: m_UseGravity
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -106,4 +110,3 @@ MonoBehaviour:
   patrolEnemyData: {fileID: 11400000, guid: 6d1e32adaf2692d4f9445201e1e2f66d, type: 2}
   speed: 0
   moveable: 0
-  waitTime: 0

--- a/Test/Assets/Prefabs/Enemy/NoBulletEnemy.prefab
+++ b/Test/Assets/Prefabs/Enemy/NoBulletEnemy.prefab
@@ -170,10 +170,10 @@ GameObject:
   - component: {fileID: 7275087655487328869}
   - component: {fileID: 8014104560786095915}
   - component: {fileID: 7256292872931493093}
-  - component: {fileID: 2234164896924348768}
   - component: {fileID: 3317964292277821450}
-  - component: {fileID: 4151815204507809134}
   - component: {fileID: -8705475340661231006}
+  - component: {fileID: 2453359114814538755}
+  - component: {fileID: 8167702804228986139}
   m_Layer: 8
   m_Name: NoBulletEnemy
   m_TagString: Untagged
@@ -250,42 +250,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!58 &2234164896924348768
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6460471003761360793}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: 0, y: 0}
-  m_Radius: 0.5
 --- !u!82 &3317964292277821450
 AudioSource:
   m_ObjectHideFlags: 0
@@ -383,33 +347,6 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
---- !u!50 &4151815204507809134
-Rigidbody2D:
-  serializedVersion: 5
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6460471003761360793}
-  m_BodyType: 0
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_GravityScale: 0
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 7
 --- !u!114 &-8705475340661231006
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -426,6 +363,54 @@ MonoBehaviour:
   DamageSound: {fileID: 8300000, guid: cdc31c7c9b1fcb842a6f9e4e3d2fa9e3, type: 3}
   enemySpawn: {fileID: 0}
   damageText: {fileID: 1570610128988094091}
+--- !u!135 &2453359114814538755
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6460471003761360793}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &8167702804228986139
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6460471003761360793}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 126
+  m_CollisionDetection: 0
 --- !u!1 &6722164026637600296
 GameObject:
   m_ObjectHideFlags: 0

--- a/Test/Assets/Prefabs/Enemy/NoBulletHolizonMoveEnemy.prefab
+++ b/Test/Assets/Prefabs/Enemy/NoBulletHolizonMoveEnemy.prefab
@@ -170,11 +170,11 @@ GameObject:
   - component: {fileID: 7275087655487328869}
   - component: {fileID: 8014104560786095915}
   - component: {fileID: 7256292872931493093}
-  - component: {fileID: 2234164896924348768}
   - component: {fileID: 3317964292277821450}
-  - component: {fileID: 4151815204507809134}
   - component: {fileID: -8705475340661231006}
   - component: {fileID: 6429249054025689727}
+  - component: {fileID: 2880583900167307755}
+  - component: {fileID: 3483630642255457550}
   m_Layer: 8
   m_Name: NoBulletHolizonMoveEnemy
   m_TagString: Untagged
@@ -251,42 +251,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!58 &2234164896924348768
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6460471003761360793}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: 0, y: 0}
-  m_Radius: 0.5
 --- !u!82 &3317964292277821450
 AudioSource:
   m_ObjectHideFlags: 0
@@ -384,33 +348,6 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
---- !u!50 &4151815204507809134
-Rigidbody2D:
-  serializedVersion: 5
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6460471003761360793}
-  m_BodyType: 0
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_GravityScale: 0
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 7
 --- !u!114 &-8705475340661231006
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -442,6 +379,54 @@ MonoBehaviour:
   patrolEnemyData: {fileID: 11400000, guid: bfcdde73abbbf8543aa60bab7ef0dfb1, type: 2}
   speed: 2
   moveable: 0
+--- !u!135 &2880583900167307755
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6460471003761360793}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &3483630642255457550
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6460471003761360793}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 126
+  m_CollisionDetection: 0
 --- !u!1 &6722164026637600296
 GameObject:
   m_ObjectHideFlags: 0

--- a/Test/Assets/Prefabs/Enemy/NoBulletMoveEnemy.prefab
+++ b/Test/Assets/Prefabs/Enemy/NoBulletMoveEnemy.prefab
@@ -170,11 +170,11 @@ GameObject:
   - component: {fileID: 7275087655487328869}
   - component: {fileID: 8014104560786095915}
   - component: {fileID: 7256292872931493093}
-  - component: {fileID: 2234164896924348768}
   - component: {fileID: 3317964292277821450}
-  - component: {fileID: 4151815204507809134}
   - component: {fileID: -8705475340661231006}
   - component: {fileID: -6838573945187210921}
+  - component: {fileID: 5838905496174877103}
+  - component: {fileID: 3635960677497582384}
   m_Layer: 8
   m_Name: NoBulletMoveEnemy
   m_TagString: Untagged
@@ -251,42 +251,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!58 &2234164896924348768
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6460471003761360793}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: 0, y: 0}
-  m_Radius: 0.5
 --- !u!82 &3317964292277821450
 AudioSource:
   m_ObjectHideFlags: 0
@@ -384,33 +348,6 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
---- !u!50 &4151815204507809134
-Rigidbody2D:
-  serializedVersion: 5
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6460471003761360793}
-  m_BodyType: 0
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_GravityScale: 0
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 7
 --- !u!114 &-8705475340661231006
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -442,7 +379,54 @@ MonoBehaviour:
   patrolEnemyData: {fileID: 11400000, guid: 6a9c8c5ce8099b14b99cf12e12dcdacd, type: 2}
   speed: 2
   moveable: 1
-  waitTime: 0.1
+--- !u!135 &5838905496174877103
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6460471003761360793}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &3635960677497582384
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6460471003761360793}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 126
+  m_CollisionDetection: 0
 --- !u!1 &6722164026637600296
 GameObject:
   m_ObjectHideFlags: 0

--- a/Test/Assets/Prefabs/Enemy/ReflectionBulletEnemy.prefab
+++ b/Test/Assets/Prefabs/Enemy/ReflectionBulletEnemy.prefab
@@ -287,9 +287,9 @@ GameObject:
   - component: {fileID: 35070926841245777}
   - component: {fileID: 6518200596960036551}
   - component: {fileID: 1212728943262155455}
-  - component: {fileID: 2241615745031438462}
   - component: {fileID: 1060190172193966603}
-  - component: {fileID: 7938764919384298346}
+  - component: {fileID: 5351518883610647845}
+  - component: {fileID: 1605732252598360778}
   m_Layer: 8
   m_Name: ReflectionBulletEnemy
   m_TagString: Untagged
@@ -397,42 +397,7 @@ MonoBehaviour:
   ShotSound: {fileID: 8300000, guid: c61f9dc4363342c47ad930f260084f8d, type: 3}
   DamageSound: {fileID: 8300000, guid: cdc31c7c9b1fcb842a6f9e4e3d2fa9e3, type: 3}
   enemySpawn: {fileID: 0}
---- !u!58 &2241615745031438462
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5786863223050452144}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: 0, y: 0}
-  m_Radius: 0.5
+  enemyHPSlider: {fileID: 0}
 --- !u!82 &1060190172193966603
 AudioSource:
   m_ObjectHideFlags: 0
@@ -530,22 +495,13 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
---- !u!50 &7938764919384298346
-Rigidbody2D:
-  serializedVersion: 5
+--- !u!135 &5351518883610647845
+SphereCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5786863223050452144}
-  m_BodyType: 0
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_GravityScale: 0
   m_Material: {fileID: 0}
   m_IncludeLayers:
     serializedVersion: 2
@@ -553,10 +509,40 @@ Rigidbody2D:
   m_ExcludeLayers:
     serializedVersion: 2
     m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &1605732252598360778
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5786863223050452144}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 0
   m_Interpolate: 0
-  m_SleepingMode: 1
+  m_Constraints: 126
   m_CollisionDetection: 0
-  m_Constraints: 7
 --- !u!1 &7802898497872903620
 GameObject:
   m_ObjectHideFlags: 0

--- a/Test/Assets/Prefabs/Enemy/ReflectionCantLoopBullet.prefab
+++ b/Test/Assets/Prefabs/Enemy/ReflectionCantLoopBullet.prefab
@@ -9,13 +9,13 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7127396871759080455}
-  - component: {fileID: 3594186629258777906}
   - component: {fileID: 7198908620252294992}
-  - component: {fileID: 1231518423397365870}
   - component: {fileID: 7962928320912812977}
   - component: {fileID: 8900184154626681027}
   - component: {fileID: 2477288409102013744}
   - component: {fileID: 4534016232990628182}
+  - component: {fileID: 3904885368426931220}
+  - component: {fileID: 7851413053791578195}
   m_Layer: 10
   m_Name: ReflectionCantLoopBullet
   m_TagString: EnemyBullet
@@ -40,42 +40,6 @@ Transform:
   - {fileID: 517479595422322583}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!58 &3594186629258777906
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1734557430232284754}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: 0, y: 0}
-  m_Radius: 0.5
 --- !u!114 &7198908620252294992
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -91,33 +55,6 @@ MonoBehaviour:
   meshRendererChild: {fileID: 8867892984592169197}
   characterParams: {fileID: 11400000, guid: ba6e45e6d168adb41bcb14b428391fe5, type: 2}
   trailRenderer: {fileID: 7729072353109492909}
---- !u!50 &1231518423397365870
-Rigidbody2D:
-  serializedVersion: 5
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1734557430232284754}
-  m_BodyType: 1
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_GravityScale: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 0
 --- !u!23 &7962928320912812977
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -221,6 +158,54 @@ MonoBehaviour:
   childObj: {fileID: 4480461824481670634}
   loop: {fileID: 2477288409102013744}
   loopAble: 0
+--- !u!135 &3904885368426931220
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1734557430232284754}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &7851413053791578195
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1734557430232284754}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!1 &3144457938912378130
 GameObject:
   m_ObjectHideFlags: 0

--- a/Test/Assets/Prefabs/Enemy/ReflectionEnemy.prefab
+++ b/Test/Assets/Prefabs/Enemy/ReflectionEnemy.prefab
@@ -170,10 +170,10 @@ GameObject:
   - component: {fileID: 7275087655487328869}
   - component: {fileID: 8014104560786095915}
   - component: {fileID: 7256292872931493093}
-  - component: {fileID: 2234164896924348768}
   - component: {fileID: 3317964292277821450}
-  - component: {fileID: 4151815204507809134}
   - component: {fileID: -8705475340661231006}
+  - component: {fileID: 7414620283106871365}
+  - component: {fileID: 1928768217759460389}
   m_Layer: 8
   m_Name: ReflectionEnemy
   m_TagString: Untagged
@@ -251,42 +251,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!58 &2234164896924348768
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6460471003761360793}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: 0, y: 0}
-  m_Radius: 0.5
 --- !u!82 &3317964292277821450
 AudioSource:
   m_ObjectHideFlags: 0
@@ -384,33 +348,6 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
---- !u!50 &4151815204507809134
-Rigidbody2D:
-  serializedVersion: 5
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6460471003761360793}
-  m_BodyType: 0
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_GravityScale: 0
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 7
 --- !u!114 &-8705475340661231006
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -427,6 +364,54 @@ MonoBehaviour:
   DamageSound: {fileID: 8300000, guid: cdc31c7c9b1fcb842a6f9e4e3d2fa9e3, type: 3}
   enemySpawn: {fileID: 0}
   damageText: {fileID: 9014513771960752724}
+--- !u!135 &7414620283106871365
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6460471003761360793}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &1928768217759460389
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6460471003761360793}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 126
+  m_CollisionDetection: 0
 --- !u!1 &6722164026637600296
 GameObject:
   m_ObjectHideFlags: 0

--- a/Test/Assets/Prefabs/Enemy/ReflectionEnemyBullet.prefab
+++ b/Test/Assets/Prefabs/Enemy/ReflectionEnemyBullet.prefab
@@ -181,13 +181,13 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3629478672760931741}
-  - component: {fileID: 2797974414932151375}
   - component: {fileID: 3840083676541887899}
-  - component: {fileID: 2119114199926552373}
   - component: {fileID: 4976443450439509812}
   - component: {fileID: 8443123524045288339}
   - component: {fileID: 4018568449771187965}
   - component: {fileID: 5779874853303082382}
+  - component: {fileID: 1994962124367393639}
+  - component: {fileID: 8618241053843844763}
   m_Layer: 10
   m_Name: ReflectionEnemyBullet
   m_TagString: EnemyBullet
@@ -212,42 +212,6 @@ Transform:
   - {fileID: 5238842158076924940}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!58 &2797974414932151375
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6079434019846936883}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: 0, y: 0}
-  m_Radius: 0.5
 --- !u!114 &3840083676541887899
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -263,33 +227,6 @@ MonoBehaviour:
   meshRendererChild: {fileID: 8488926800957728563}
   characterParams: {fileID: 11400000, guid: ba6e45e6d168adb41bcb14b428391fe5, type: 2}
   trailRenderer: {fileID: 5618787314213964913}
---- !u!50 &2119114199926552373
-Rigidbody2D:
-  serializedVersion: 5
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6079434019846936883}
-  m_BodyType: 1
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_GravityScale: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 0
 --- !u!23 &4976443450439509812
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -393,3 +330,51 @@ MonoBehaviour:
   childObj: {fileID: 3939702617726632076}
   loop: {fileID: 4018568449771187965}
   loopAble: 1
+--- !u!135 &1994962124367393639
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6079434019846936883}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &8618241053843844763
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6079434019846936883}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0

--- a/Test/Assets/Prefabs/Enemy/VerticalPatrolEnemy.prefab
+++ b/Test/Assets/Prefabs/Enemy/VerticalPatrolEnemy.prefab
@@ -35,7 +35,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 1.2200003, y: 3.94974}
+  m_AnchoredPosition: {x: 0, y: 0.77}
   m_SizeDelta: {x: 200, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7836170940388550999
@@ -321,9 +321,9 @@ GameObject:
   - component: {fileID: 7968286822431102759}
   - component: {fileID: 5627829666097525595}
   - component: {fileID: 4265780119909550230}
-  - component: {fileID: 5127113108378831449}
   - component: {fileID: 4609709058680873958}
-  - component: {fileID: 3209635841515644549}
+  - component: {fileID: 1562194468703511483}
+  - component: {fileID: 6005294431132381305}
   m_Layer: 0
   m_Name: VerticalPatrolEnemy
   m_TagString: Untagged
@@ -433,7 +433,7 @@ MonoBehaviour:
   HP: 16
   damageText: {fileID: 8597574886849479444}
   beforeAttackText: {fileID: 7930962146855206665}
-  beforeAttackTime: 0
+  beforeAttackTime: 1
   blinkDuration: 0.2
   canvas: {fileID: 8136479408866247873}
   shotObj: {fileID: 0}
@@ -441,47 +441,12 @@ MonoBehaviour:
   dontAttck: 0
   bullet: {fileID: 0}
   enemyBullet: {fileID: 1057501140420241128, guid: 836e0d637f444dd449b950db9143b306, type: 3}
-  reflectionBullet: {fileID: 6079434019846936883, guid: 292132853404cfc4aa1daac75686c34d, type: 3}
+  reflectionBullet: {fileID: 1734557430232284754, guid: 50aaa5bb5e5a5f44fa3f2ac7b7cb1f5d, type: 3}
   bulletRate: 4
   ShotSound: {fileID: 8300000, guid: c61f9dc4363342c47ad930f260084f8d, type: 3}
   DamageSound: {fileID: 8300000, guid: cdc31c7c9b1fcb842a6f9e4e3d2fa9e3, type: 3}
   enemySpawn: {fileID: 0}
---- !u!58 &5127113108378831449
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7775727996460671959}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: 0, y: 0}
-  m_Radius: 0.5
+  enemyHPSlider: {fileID: 0}
 --- !u!82 &4609709058680873958
 AudioSource:
   m_ObjectHideFlags: 0
@@ -579,22 +544,13 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
---- !u!50 &3209635841515644549
-Rigidbody2D:
-  serializedVersion: 5
+--- !u!135 &1562194468703511483
+SphereCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7775727996460671959}
-  m_BodyType: 0
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_GravityScale: 1
   m_Material: {fileID: 0}
   m_IncludeLayers:
     serializedVersion: 2
@@ -602,10 +558,40 @@ Rigidbody2D:
   m_ExcludeLayers:
     serializedVersion: 2
     m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &6005294431132381305
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7775727996460671959}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 0
   m_Interpolate: 0
-  m_SleepingMode: 1
+  m_Constraints: 126
   m_CollisionDetection: 0
-  m_Constraints: 7
 --- !u!1 &8136479408866247873
 GameObject:
   m_ObjectHideFlags: 0

--- a/Test/Assets/Prefabs/EnemyBullet.prefab
+++ b/Test/Assets/Prefabs/EnemyBullet.prefab
@@ -10,9 +10,9 @@ GameObject:
   m_Component:
   - component: {fileID: 2181899153122864126}
   - component: {fileID: 6639989638481993967}
-  - component: {fileID: 4780306026954559086}
-  - component: {fileID: -7450406237200699315}
   - component: {fileID: 4601332833219182317}
+  - component: {fileID: 4252715897536550183}
+  - component: {fileID: 1879892116199914363}
   m_Layer: 10
   m_Name: EnemyBullet
   m_TagString: EnemyBullet
@@ -91,69 +91,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!58 &4780306026954559086
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1057501140420241128}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: 0, y: 0}
-  m_Radius: 0.5
---- !u!50 &-7450406237200699315
-Rigidbody2D:
-  serializedVersion: 5
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1057501140420241128}
-  m_BodyType: 1
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_GravityScale: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 0
 --- !u!114 &4601332833219182317
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -167,6 +104,54 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Power: 6.7
+--- !u!135 &4252715897536550183
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1057501140420241128}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &1879892116199914363
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1057501140420241128}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!1 &5919746632611300560
 GameObject:
   m_ObjectHideFlags: 0

--- a/Test/Assets/Prefabs/FloatArea/Old/FloatArea.prefab
+++ b/Test/Assets/Prefabs/FloatArea/Old/FloatArea.prefab
@@ -70,23 +70,20 @@ PrefabInstance:
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: d35de87ca8b27a949b796b4c831c4f16, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 7314677406428883410}
+      addedObject: {fileID: 8106151573002770688}
   m_SourcePrefab: {fileID: 100100000, guid: d35de87ca8b27a949b796b4c831c4f16, type: 3}
 --- !u!1 &7996641272575461418 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: d35de87ca8b27a949b796b4c831c4f16, type: 3}
   m_PrefabInstance: {fileID: 7077599295320077691}
   m_PrefabAsset: {fileID: 0}
---- !u!61 &7314677406428883410
-BoxCollider2D:
+--- !u!65 &8106151573002770688
+BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7996641272575461418}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
   m_Material: {fileID: 0}
   m_IncludeLayers:
     serializedVersion: 2
@@ -95,31 +92,9 @@ BoxCollider2D:
     serializedVersion: 2
     m_Bits: 0
   m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
   m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: 0.018306017, y: -0.004878044}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  m_Size: {x: 2.8951979, y: 0.20970678}
-  m_EdgeRadius: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 2.56, y: 0.17, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Test/Assets/Prefabs/Loop Area.prefab
+++ b/Test/Assets/Prefabs/Loop Area.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 6452938595965143223}
   - component: {fileID: 554075227881103782}
   - component: {fileID: 4757692399975902272}
-  - component: {fileID: 5716307075337327074}
+  - component: {fileID: 3607305621383386462}
   m_Layer: 0
   m_Name: Loop Area
   m_TagString: LoopArea
@@ -87,16 +87,13 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!61 &5716307075337327074
-BoxCollider2D:
+--- !u!65 &3607305621383386462
+BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6639228919903405143}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
   m_Material: {fileID: 0}
   m_IncludeLayers:
     serializedVersion: 2
@@ -105,31 +102,9 @@ BoxCollider2D:
     serializedVersion: 2
     m_Bits: 0
   m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
   m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  m_Size: {x: 1, y: 0.99999994}
-  m_EdgeRadius: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 0.99999994, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Test/Assets/Prefabs/Player.prefab
+++ b/Test/Assets/Prefabs/Player.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 51646320031398143}
   - component: {fileID: 1107572921369228192}
   - component: {fileID: 1612769258713882027}
-  - component: {fileID: 7706942183368483096}
+  - component: {fileID: 7490743360330475868}
   m_Layer: 0
   m_Name: Attack
   m_TagString: Attack
@@ -87,16 +87,13 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!61 &7706942183368483096
-BoxCollider2D:
+--- !u!65 &7490743360330475868
+BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 485489305804183711}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
   m_Material: {fileID: 0}
   m_IncludeLayers:
     serializedVersion: 2
@@ -105,34 +102,12 @@ BoxCollider2D:
     serializedVersion: 2
     m_Bits: 0
   m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
   m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: 0.009636879, y: 0.019340634}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  m_Size: {x: 1.3264873, y: 1.136728}
-  m_EdgeRadius: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1.0000005, y: 1, z: 0.3}
+  m_Center: {x: -0.2, y: 0, z: -2.842171e-14}
 --- !u!1 &1357996293472408271
 GameObject:
   m_ObjectHideFlags: 0
@@ -423,7 +398,7 @@ GameObject:
   - component: {fileID: 5767248745091277293}
   - component: {fileID: 2458167737731534691}
   - component: {fileID: 1068285489982006016}
-  - component: {fileID: 8509207625293510070}
+  - component: {fileID: 1897778218254397930}
   m_Layer: 0
   m_Name: 'QuickAttack '
   m_TagString: QuickAttack
@@ -499,16 +474,13 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!61 &8509207625293510070
-BoxCollider2D:
+--- !u!65 &1897778218254397930
+BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4345442053038248739}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
   m_Material: {fileID: 0}
   m_IncludeLayers:
     serializedVersion: 2
@@ -517,34 +489,12 @@ BoxCollider2D:
     serializedVersion: 2
     m_Bits: 0
   m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
   m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: 0.009636879, y: 0.019340634}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  m_Size: {x: 1.3264873, y: 1.136728}
-  m_EdgeRadius: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1.0000005, y: 1, z: 0.3}
+  m_Center: {x: -0.2, y: 0, z: -2.842171e-14}
 --- !u!1 &4416818167434436339
 GameObject:
   m_ObjectHideFlags: 0
@@ -556,8 +506,8 @@ GameObject:
   - component: {fileID: 2900939417993952395}
   - component: {fileID: 350047999521084643}
   - component: {fileID: 3502026795929391404}
-  - component: {fileID: 3557629620860895243}
   - component: {fileID: 2463885730904072355}
+  - component: {fileID: 576870663172480296}
   m_Layer: 0
   m_Name: collision
   m_TagString: Player
@@ -574,7 +524,7 @@ Transform:
   m_GameObject: {fileID: 4416818167434436339}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0.7071068, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: -0.09, y: 0.817, z: -0.013}
+  m_LocalPosition: {x: 0, y: 1, z: 0}
   m_LocalScale: {x: 0.17151225, y: 0.8756299, z: 0.6844064}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -634,43 +584,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!70 &3557629620860895243
-CapsuleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4416818167434436339}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: -0.008154303, y: 0.030223887}
-  m_Size: {x: 0.8327286, y: 1.9176978}
-  m_Direction: 0
 --- !u!114 &2463885730904072355
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -690,6 +603,29 @@ MonoBehaviour:
   animator: {fileID: 8906615988043019670}
   hitEffect: {fileID: 441973028638082585}
   hitTime: 1
+--- !u!136 &576870663172480296
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4416818167434436339}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.3
+  m_Height: 1.9999998
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0.000000029802322}
 --- !u!1 &4827083004097579758
 GameObject:
   m_ObjectHideFlags: 0
@@ -1617,13 +1553,13 @@ PrefabInstance:
       addedObject: {fileID: 163183520200374533}
     - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 36d1d75eba48ad74c9d9cb085d1acdaa, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 8526654989230650005}
-    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 36d1d75eba48ad74c9d9cb085d1acdaa, type: 3}
-      insertIndex: -1
       addedObject: {fileID: 3485683195366542829}
     - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 36d1d75eba48ad74c9d9cb085d1acdaa, type: 3}
       insertIndex: -1
       addedObject: {fileID: 5542048663544205056}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 36d1d75eba48ad74c9d9cb085d1acdaa, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 5879151361752933288}
   m_SourcePrefab: {fileID: 100100000, guid: 36d1d75eba48ad74c9d9cb085d1acdaa, type: 3}
 --- !u!4 &3782708181428690570 stripped
 Transform:
@@ -1718,6 +1654,7 @@ MonoBehaviour:
   playerUI: {fileID: 4782663261511517043, guid: 9d9d3cd79e148d442ae05fe8cbb5a99f, type: 3}
   mapManager: {fileID: 0}
   sceneButtonManager: {fileID: 0}
+  jumpCount: 0
   IsAttacking: 0
   ShotPosition: {fileID: 4827083004097579758}
   AttackCollision: {fileID: 485489305804183711}
@@ -1847,33 +1784,6 @@ MonoBehaviour:
   m_DefaultActionMap: Player
   m_SplitScreenIndex: -1
   m_Camera: {fileID: 0}
---- !u!50 &8526654989230650005
-Rigidbody2D:
-  serializedVersion: 5
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4554601162387817520}
-  m_BodyType: 0
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_GravityScale: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 4
 --- !u!82 &3485683195366542829
 AudioSource:
   m_ObjectHideFlags: 0
@@ -1983,6 +1893,33 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5048839d001741dab5ff90d7d89a7bbf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!54 &5879151361752933288
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4554601162387817520}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 112
+  m_CollisionDetection: 0
 --- !u!1001 &4257200145138863502
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Test/Assets/Prefabs/ReflectWall.prefab
+++ b/Test/Assets/Prefabs/ReflectWall.prefab
@@ -11,8 +11,8 @@ GameObject:
   - component: {fileID: 2220819023555158640}
   - component: {fileID: 3364634941493370209}
   - component: {fileID: 517078804206425625}
-  - component: {fileID: 8008876372953799024}
   - component: {fileID: 3814289518385002433}
+  - component: {fileID: 1215764527181084263}
   m_Layer: 0
   m_Name: ReflectWall
   m_TagString: Untagged
@@ -89,52 +89,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!61 &8008876372953799024
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 343241532328628416}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  m_Size: {x: 1, y: 1}
-  m_EdgeRadius: 0
 --- !u!114 &3814289518385002433
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -147,6 +101,27 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5d8367cf8f7945b6b6d2dd443c95a780, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!65 &1215764527181084263
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 343241532328628416}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 0.99999994, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &7152716649102912868
 GameObject:
   m_ObjectHideFlags: 0
@@ -158,7 +133,7 @@ GameObject:
   - component: {fileID: 310369775239537565}
   - component: {fileID: 8500609822100528718}
   - component: {fileID: 2737362412626606325}
-  - component: {fileID: 5083906288520843940}
+  - component: {fileID: 1142638538052346028}
   m_Layer: 0
   m_Name: Cube (8)
   m_TagString: Ground
@@ -234,16 +209,13 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!61 &5083906288520843940
-BoxCollider2D:
+--- !u!65 &1142638538052346028
+BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7152716649102912868}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
   m_Material: {fileID: 0}
   m_IncludeLayers:
     serializedVersion: 2
@@ -252,31 +224,9 @@ BoxCollider2D:
     serializedVersion: 2
     m_Bits: 0
   m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
   m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  m_Size: {x: 1, y: 1}
-  m_EdgeRadius: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 0.99999994, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Test/Assets/Prefabs/Sield.prefab
+++ b/Test/Assets/Prefabs/Sield.prefab
@@ -11,9 +11,8 @@ GameObject:
   - component: {fileID: 341449541034536326}
   - component: {fileID: 5710288349256233593}
   - component: {fileID: 2503280426236596420}
-  - component: {fileID: 6100874081971647409}
-  - component: {fileID: 1349029987762722371}
   - component: {fileID: 3659528371099611498}
+  - component: {fileID: 4228970999530789160}
   m_Layer: 0
   m_Name: Sield
   m_TagString: Untagged
@@ -89,71 +88,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!61 &6100874081971647409
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 744760045719927192}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 1
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  m_Size: {x: 1, y: 1}
-  m_EdgeRadius: 0
---- !u!251 &1349029987762722371
-PlatformEffector2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 744760045719927192}
-  m_Enabled: 1
-  m_UseColliderMask: 1
-  m_ColliderMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_RotationalOffset: 90
-  m_UseOneWay: 1
-  m_UseOneWayGrouping: 0
-  m_SurfaceArc: 180
-  m_UseSideFriction: 0
-  m_UseSideBounce: 0
-  m_SideArc: 1
 --- !u!114 &3659528371099611498
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -167,3 +101,24 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   shieldPosition: 0
+--- !u!65 &4228970999530789160
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 744760045719927192}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 0.99999994, y: 0.99999994, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Test/Assets/Prefabs/Warning.prefab
+++ b/Test/Assets/Prefabs/Warning.prefab
@@ -102,7 +102,7 @@ BoxCollider:
     serializedVersion: 2
     m_Bits: 0
   m_LayerOverridePriority: 0
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3

--- a/Test/Assets/Prefabs/WarpZone.prefab
+++ b/Test/Assets/Prefabs/WarpZone.prefab
@@ -12,8 +12,8 @@ GameObject:
   - component: {fileID: 8023251177633083253}
   - component: {fileID: 1895402930162779118}
   - component: {fileID: 2008806073583735861}
-  - component: {fileID: 7076701722084165667}
-  - component: {fileID: 8716129878195396710}
+  - component: {fileID: 429542522842289977}
+  - component: {fileID: 333820912652067723}
   m_Layer: 0
   m_Name: WarpZone
   m_TagString: Untagged
@@ -105,16 +105,13 @@ MonoBehaviour:
   Tags:
   - Player
   - Bullet
---- !u!58 &7076701722084165667
-CircleCollider2D:
+--- !u!135 &429542522842289977
+SphereCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6101501329489277467}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
   m_Material: {fileID: 0}
   m_IncludeLayers:
     serializedVersion: 2
@@ -123,48 +120,36 @@ CircleCollider2D:
     serializedVersion: 2
     m_Bits: 0
   m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
   m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: 0, y: 0}
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
   m_Radius: 5
---- !u!50 &8716129878195396710
-Rigidbody2D:
-  serializedVersion: 5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &333820912652067723
+Rigidbody:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6101501329489277467}
-  m_BodyType: 0
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
+  serializedVersion: 4
   m_Mass: 1
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_GravityScale: 0
-  m_Material: {fileID: 0}
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
   m_IncludeLayers:
     serializedVersion: 2
     m_Bits: 0
   m_ExcludeLayers:
     serializedVersion: 2
     m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 0
   m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
   m_Constraints: 0
+  m_CollisionDetection: 0

--- a/Test/Assets/Prefabs/WeakAttackReflector.prefab
+++ b/Test/Assets/Prefabs/WeakAttackReflector.prefab
@@ -11,9 +11,9 @@ GameObject:
   - component: {fileID: 8892352445300211803}
   - component: {fileID: 6909778885738651916}
   - component: {fileID: 4362389341562285804}
-  - component: {fileID: 4568699384395901699}
   - component: {fileID: 4223538428538908195}
-  - component: {fileID: 4737092837754772252}
+  - component: {fileID: 5407919024962464668}
+  - component: {fileID: 1062745915777014244}
   m_Layer: 0
   m_Name: WeakAttackReflector
   m_TagString: Untagged
@@ -89,42 +89,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!58 &4568699384395901699
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1875006491058082821}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: 0, y: 0}
-  m_Radius: 0.5
 --- !u!114 &4223538428538908195
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -138,22 +102,13 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   destroyBulletCount: 1
---- !u!50 &4737092837754772252
-Rigidbody2D:
-  serializedVersion: 5
+--- !u!135 &5407919024962464668
+SphereCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1875006491058082821}
-  m_BodyType: 0
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1000
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_GravityScale: 0
   m_Material: {fileID: 0}
   m_IncludeLayers:
     serializedVersion: 2
@@ -161,7 +116,37 @@ Rigidbody2D:
   m_ExcludeLayers:
     serializedVersion: 2
     m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.49999997
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &1062745915777014244
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1875006491058082821}
+  serializedVersion: 4
+  m_Mass: 1000
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 0
   m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 1
   m_Constraints: 0
+  m_CollisionDetection: 0

--- a/Test/Assets/Scenes/3DColliderTest.unity
+++ b/Test/Assets/Scenes/3DColliderTest.unity
@@ -181,7 +181,7 @@ Transform:
   m_GameObject: {fileID: 121238049}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -4.6, y: 25.01, z: -35.861046}
+  m_LocalPosition: {x: -5, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -212,7 +212,7 @@ Transform:
   m_GameObject: {fileID: 183441890}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -4.5, y: 22.27, z: -35.861046}
+  m_LocalPosition: {x: 5, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -384,6 +384,14 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: conditionToSpawn.Array.size
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: enemiesToSpawn.Array.data[0].enemyId
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
       propertyPath: enemiesToSpawn.Array.data[0].spawnDelay
       value: 3
       objectReference: {fileID: 0}
@@ -394,7 +402,135 @@ PrefabInstance:
     - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
       propertyPath: enemiesToSpawn.Array.data[0].enemyPrefab
       value: 
+      objectReference: {fileID: 6460471003761360793, guid: cbb58e3e718a4ca4eaf675e225fb9eb6, type: 3}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: conditionToSpawn.Array.data[0].spawnPoint
+      value: 
+      objectReference: {fileID: 121238050}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: conditionToSpawn.Array.data[1].spawnPoint
+      value: 
+      objectReference: {fileID: 1679916586}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: conditionToSpawn.Array.data[2].spawnPoint
+      value: 
+      objectReference: {fileID: 907227207}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: conditionToSpawn.Array.data[3].spawnPoint
+      value: 
+      objectReference: {fileID: 1124055354}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: conditionToSpawn.Array.data[4].spawnPoint
+      value: 
+      objectReference: {fileID: 183441891}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: conditionToSpawn.Array.data[0].conditionId
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: conditionToSpawn.Array.data[1].conditionId
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: conditionToSpawn.Array.data[2].conditionId
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: conditionToSpawn.Array.data[3].conditionId
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: conditionToSpawn.Array.data[4].conditionId
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: conditionToSpawn.Array.data[0].conditionGameObject
+      value: 
+      objectReference: {fileID: 7775727996460671959, guid: 4021bd9e6bb076446a2a758004412859, type: 3}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: conditionToSpawn.Array.data[0].conditionSpawnDelay
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: conditionToSpawn.Array.data[1].conditionGameObject
+      value: 
+      objectReference: {fileID: 2572537564279502643, guid: 85d8f584e312a2543bd1bee1ff948b9e, type: 3}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: conditionToSpawn.Array.data[1].conditionSpawnDelay
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: conditionToSpawn.Array.data[2].conditionGameObject
+      value: 
+      objectReference: {fileID: 6460471003761360793, guid: f9bdf48188d13414a8bafe671b18a979, type: 3}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: conditionToSpawn.Array.data[2].conditionSpawnDelay
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: conditionToSpawn.Array.data[3].conditionGameObject
+      value: 
       objectReference: {fileID: 2313769065159366323, guid: fec80a1e787113d41994db2f338379b6, type: 3}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: conditionToSpawn.Array.data[3].conditionSpawnDelay
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: conditionToSpawn.Array.data[4].conditionGameObject
+      value: 
+      objectReference: {fileID: 6460471003761360793, guid: 085027a2192f29148b1e3ccdbf4f6b39, type: 3}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: conditionToSpawn.Array.data[4].conditionSpawnDelay
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: conditionToSpawn.Array.data[0].conditionEnemyIds.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: conditionToSpawn.Array.data[1].conditionEnemyIds.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: conditionToSpawn.Array.data[2].conditionEnemyIds.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: conditionToSpawn.Array.data[3].conditionEnemyIds.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: conditionToSpawn.Array.data[4].conditionEnemyIds.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: 'conditionToSpawn.Array.data[0].conditionEnemyIds.Array.data[0]'
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: 'conditionToSpawn.Array.data[1].conditionEnemyIds.Array.data[0]'
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: 'conditionToSpawn.Array.data[2].conditionEnemyIds.Array.data[0]'
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: 'conditionToSpawn.Array.data[3].conditionEnemyIds.Array.data[0]'
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: 'conditionToSpawn.Array.data[3].conditionEnemyIds.Array.data[1]'
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: 'conditionToSpawn.Array.data[4].conditionEnemyIds.Array.data[0]'
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6797630135018218613, guid: a6530c668a42a98498ec557efab67d21, type: 3}
+      propertyPath: 'conditionToSpawn.Array.data[4].conditionEnemyIds.Array.data[1]'
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 7414324679359569832, guid: a6530c668a42a98498ec557efab67d21, type: 3}
       propertyPath: m_Name
       value: Manager
@@ -837,7 +973,7 @@ Transform:
   m_GameObject: {fileID: 907227206}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 7.5, y: 22.27, z: -35.861046}
+  m_LocalPosition: {x: 0, y: -3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1430,7 +1566,7 @@ Transform:
   m_GameObject: {fileID: 1124196128}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -4.6, y: 18.980627, z: -35.861046}
+  m_LocalPosition: {x: -5, y: -3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1881,7 +2017,7 @@ Transform:
   m_GameObject: {fileID: 1679916585}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 7.5, y: 25.01, z: -35.861046}
+  m_LocalPosition: {x: 5, y: -3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Test/Assets/Scenes/3DColliderTest.unity.meta
+++ b/Test/Assets/Scenes/3DColliderTest.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: cbefb8a4a625de241af4a55bae71dfd3
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Test/Assets/Scripts/Bullet.cs
+++ b/Test/Assets/Scripts/Bullet.cs
@@ -165,15 +165,67 @@ namespace Scripts
             damageByReflectionCount = characterParams.damageByReflectionCount;
             reflectInvincible = characterParams.reflectInvincible;
         }
-        private void OnTriggerEnter2D(Collider2D collision)
+
+        void OnTriggerEnter(Collider collider)
         {
-            if (collision.gameObject.tag == "Ground"&& !isAttack)
+            if (collider.gameObject.tag == "Ground"&& !isAttack)
             {
-                if (collision.TryGetComponent<PlayerStatus>(out PlayerStatus status))
+                if (collider.gameObject.layer == LayerMask.NameToLayer("FloatFloor"))
+                    return;
+
+                //ResetBullet();
+                Time.timeScale = 1f;
+                player.isMove = true;
+                isAttack = false;
+                destroyed = true;
+                Destroy(this.gameObject);
+            }
+            if (collider.gameObject.tag == "Player" && !isAttack)
+            {
+                if(!CompareTag("EnemyBullet")) return;
+                if (collider.TryGetComponent<PlayerStatus>(out PlayerStatus status))
                 {
                     status.Damage(1);
                 }
 
+                //ResetBullet();
+                Time.timeScale = 1f;
+                player.isMove = true;
+                isAttack = false;
+                destroyed = true;
+                Destroy(this.gameObject);
+            }
+            if (collider.gameObject.tag == "Attack" && !destroyed)
+            {
+                pStatus.StartReflectInvincibility(1000);
+                player.isMove = false;
+                isPaused = true;
+                player.Arrow.SetActive(true);
+                isAttack = true;
+                Time.timeScale = 0.2f;
+                power = UnityEngine.Vector3.zero;
+                //Invoke("Attack", 0.3f);
+
+            }
+
+            if (collider.gameObject.tag == "QuickAttack" && !destroyed)
+            {
+                pStatus.StartReflectInvincibility(1000);
+                player.isMove = false;
+                isQuick = true;
+                SavePower = -power;
+                //Power = UnityEngine.Vector3.zero;
+                QuickAttack();
+
+            }
+        }
+        private void OnTriggerEnter2D(Collider2D collision)
+        {
+            if (collision.gameObject.tag == "Ground"&& !isAttack)
+            {
+                if (collision.gameObject.layer == LayerMask.NameToLayer("FloatFloor"))
+                return;
+                
                 //ResetBullet();
                 Time.timeScale = 1f;
                 player.isMove = true;
@@ -206,7 +258,6 @@ namespace Scripts
                 Time.timeScale = 0.2f;
                 power = UnityEngine.Vector3.zero;
                 //Invoke("Attack", 0.3f);
-
             }
 
             if (collision.gameObject.tag == "QuickAttack" && !destroyed)
@@ -217,7 +268,6 @@ namespace Scripts
                 SavePower = -power;
                 //Power = UnityEngine.Vector3.zero;
                 QuickAttack();
-
             }
         }
         
@@ -350,7 +400,7 @@ namespace Scripts
             float correctionAimPos = 1.5f;
             float Angle = Mathf.Atan2(player.gameObject.transform.position.y - Pos.y + correctionAimPos,
                 player.gameObject.transform.position.x - Pos.x);
-            Debug.Log("角度:"+Angle);
+            //Debug.Log("角度:"+Angle);
             Vector3 direction = new Vector3(Mathf.Cos(Angle), Mathf.Sin(Angle), 0).normalized;
             power = direction;
             PowerDirection = 1f;

--- a/Test/Assets/Scripts/CameraAreaManager.cs
+++ b/Test/Assets/Scripts/CameraAreaManager.cs
@@ -22,8 +22,8 @@ public class CameraAreaManager : MonoBehaviour
     {
         leftDownPosition = Camera.main.ViewportToWorldPoint(Vector2.zero);
         rightUpPosition = Camera.main.ViewportToWorldPoint(Vector2.one);
-        Debug.Log("画面の左下の座標は " + leftDownPosition + " です");
-        Debug.Log("画面の右上の座標は " + rightUpPosition + " です");
+        // Debug.Log("画面の左下の座標は " + leftDownPosition + " です");
+        // Debug.Log("画面の右上の座標は " + rightUpPosition + " です");
         
         leftMax = Rounding(leftDownPosition.x + enemySize);
         rightMax = Rounding(rightUpPosition.x - enemySize);

--- a/Test/Assets/Scripts/Enemy.cs
+++ b/Test/Assets/Scripts/Enemy.cs
@@ -66,7 +66,7 @@ namespace Scripts
 
         [SerializeField] [JapaneseLabel("敵のHPバー")] private Slider enemyHPSlider;
         
-        private Collider2D loopAreaCollider;
+        private Collider loopAreaCollider;
 
         private float minX, maxX, minY, maxY;
 
@@ -79,7 +79,7 @@ namespace Scripts
             GameObject loopAreaObj = GameObject.FindWithTag("LoopArea");
             if (loopAreaObj != null)
             {
-                loopAreaCollider = loopAreaObj.GetComponent<Collider2D>();
+                loopAreaCollider = loopAreaObj.GetComponent<Collider>();
             }
             else
             {
@@ -189,13 +189,19 @@ namespace Scripts
                 else
                 {
                     Vector3 pos = transform.position;
-                    if (pos.x > maxX) pos.x = maxX - enemySize;
-                    else if (pos.x < minX) pos.x = minX + enemySize;
+                    if (pos.x > maxX)
+                    {
+                        pos.x = maxX - enemySize;
+                    }
+                    else if (pos.x < minX)
+                    {
+                        pos.x = minX + enemySize;
+                    }
 
                     if (pos.y > maxY)
                     {
                         pos.y = maxY - enemySize;
-                        GetComponent<Rigidbody2D>().linearVelocity = new Vector2(0, 0);
+                        GetComponent<Rigidbody>().linearVelocity = new Vector2(0, 0);
                     }
                     else if (pos.y < minY) pos.y = minY + enemySize;
 
@@ -205,6 +211,41 @@ namespace Scripts
             }
         }
 
+        void OnTriggerEnter(Collider collider)
+        {
+            if (collider.gameObject.tag == "Bullet")
+            {
+                Debug.Log("当たった");
+                Bullet bullet = collider.gameObject.GetComponent<Bullet>();
+                HP -= bullet.Damage;
+                
+                if (enemyHPSlider != null)
+                {
+                    enemyHPSlider.value = HP;
+                }
+                // DamageText.enabled = true;
+                // DamageText.text = bullet.Damage.ToString();
+                damageText.ShowDamage(bullet.Damage);
+                audioSource.PlayOneShot(DamageSound);
+            }
+
+            if (HP <= 0)
+            {
+                switch (enemyType)
+                {
+                    case EnemyType.normal:
+                        enemySpawn.RemoveEnemy(this.gameObject);
+                        break;
+                    case EnemyType.shield:
+                        enemySpawn.RemoveEnemy(this.gameObject.transform.parent.gameObject);
+                        break;
+                    case EnemyType.boss:
+                        enemySpawn.RemoveEnemy(this.gameObject.transform.parent.gameObject);
+                        break;
+                }
+            }
+        }
+        
         private void OnTriggerEnter2D(Collider2D collision)
         {
             //if (collision.gameObject.tag == "Attack")

--- a/Test/Assets/Scripts/Enemy/Laser.cs
+++ b/Test/Assets/Scripts/Enemy/Laser.cs
@@ -1,18 +1,19 @@
+using System;
 using Scripts;
 using UnityEngine;
 
 public class Laser : MonoBehaviour
 {
-    // Start is called once before the first execution of Update after the MonoBehaviour is created
-    void Start()
+    private void OnTriggerEnter(Collider other)
     {
-        
-    }
-
-    // Update is called once per frame
-    void Update()
-    {
-        
+        if (other.tag == "Player")
+        {
+            Debug.Log("LaserHit");
+            if (other.TryGetComponent<PlayerStatus>(out PlayerStatus status))
+            {
+                status.Damage(1);
+            }
+        }
     }
 
     void OnTriggerEnter2D(Collider2D other)

--- a/Test/Assets/Scripts/EnemyBullet.cs
+++ b/Test/Assets/Scripts/EnemyBullet.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Numerics;
@@ -55,6 +56,22 @@ namespace Scripts
             }
         }
 
+        private void OnTriggerEnter(Collider collider)
+        {
+            if (collider.gameObject.layer == LayerMask.NameToLayer("FloatFloor"))
+                return;
+            
+            if (collider.gameObject.tag == "Ground" || collider.gameObject.tag == "Player")
+            {
+                if (collider.TryGetComponent<PlayerStatus>(out PlayerStatus status))
+                {
+                    status.Damage(1);
+                }
+
+                Destroy(this.gameObject);
+            }
+        }
+
         private void OnTriggerEnter2D(Collider2D collision)
         {
             if (collision.gameObject.tag == "Ground" || collision.gameObject.tag == "Player")
@@ -66,7 +83,6 @@ namespace Scripts
 
                 Destroy(this.gameObject);
             }
-
         }
     }
 }

--- a/Test/Assets/Scripts/EnemyPatrol.cs
+++ b/Test/Assets/Scripts/EnemyPatrol.cs
@@ -8,9 +8,9 @@ public class EnemyPatrol : MonoBehaviour
     [SerializeField] PatrolEnemyData patrolEnemyData;
     [SerializeField] float speed;
     private float leftMax, rightMax, upMax, downMax;
-    Vector2 movement;
+    [SerializeField] Vector2 movement;
     [SerializeField] private bool moveable;
-    private Collider2D loopAreaCollider;
+    private Collider loopAreaCollider;
     private float enemySize = 0.5f;
     private Vector3 basePos;
     
@@ -19,7 +19,7 @@ public class EnemyPatrol : MonoBehaviour
         GameObject loopAreaObj = GameObject.FindWithTag("LoopArea");
         if (loopAreaObj != null)
         {
-            loopAreaCollider = loopAreaObj.GetComponent<Collider2D>();
+            loopAreaCollider = loopAreaObj.GetComponent<Collider>();
         }
         else
         {
@@ -33,19 +33,21 @@ public class EnemyPatrol : MonoBehaviour
     {
         Bounds bounds = loopAreaCollider.bounds;
         basePos = transform.position;
+        //Debug.Log("basePos:"+basePos);
         
         leftMax = basePos.x - patrolEnemyData.LeftRange;
         rightMax = basePos.x + patrolEnemyData.RightRange;
         downMax = basePos.y - patrolEnemyData.DownRange;
         upMax = basePos.y + patrolEnemyData.UpRange;
+        // Debug.Log("画面左:"+bounds.min.x+"画面右:"+bounds.max.x+"画面上:"+bounds.max.y+"画面下:"+bounds.min.y);
+        // Debug.Log("left:"+leftMax+"right:"+rightMax+"up:"+upMax+"down:"+downMax);
 
         leftMax = bounds.min.x + enemySize < leftMax ? leftMax : bounds.min.x + enemySize;
         rightMax = bounds.max.x - enemySize > rightMax ? rightMax : bounds.max.x - enemySize;
         downMax = bounds.min.y + enemySize < downMax ? downMax : bounds.min.y + enemySize;
         upMax = bounds.max.y - enemySize > upMax ? upMax : bounds.max.y - enemySize;
         
-        // Debug.Log("画面左:"+bounds.min.x+"画面右:"+bounds.max.x+"画面上:"+bounds.max.y+"画面下:"+bounds.min.y);
-        // Debug.Log("left:"+leftMax+"right:"+rightMax+"up:"+upMax+"down:"+downMax);
+        //Debug.Log("left:"+leftMax+"right:"+rightMax+"up:"+upMax+"down:"+downMax);
         
         switch (patrolEnemyData.State)
         {
@@ -111,6 +113,7 @@ public class EnemyPatrol : MonoBehaviour
             default:
                 return;
         }
+        transform.position = pos;
 
         if (moveable == false)
         {
@@ -121,6 +124,17 @@ public class EnemyPatrol : MonoBehaviour
     void ChangeMoveable()
     {
         moveable = !moveable;
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        //地面、もしくは壁に当たった時に折り返す(壁の場合は未実装)
+        if(other.gameObject.CompareTag("Ground"))
+        {
+            moveable = false;
+            movement *= -1;
+            Invoke("ChangeMoveable", patrolEnemyData.WaitTime);
+        }
     }
 
     private void OnCollisionEnter2D(Collision2D other)

--- a/Test/Assets/Scripts/Loop.cs
+++ b/Test/Assets/Scripts/Loop.cs
@@ -4,7 +4,7 @@ namespace Scripts
 {
     public class Loop : MonoBehaviour
     {
-        private Collider2D loopAreaCollider;
+        private Collider loopAreaCollider;
 
         private float minX, maxX, minY, maxY;
 
@@ -12,7 +12,7 @@ namespace Scripts
         {
             var loopAreaObj = GameObject.FindWithTag("LoopArea");
             if (loopAreaObj != null)
-                loopAreaCollider = loopAreaObj.GetComponent<Collider2D>();
+                loopAreaCollider = loopAreaObj.GetComponent<Collider>();
             else
                 Debug.LogError("LoopAreaColliderが見つかりません。LoopAreaタグを持つGameObjectを配置してください。");
         }

--- a/Test/Assets/Scripts/NoBulletEnemy.cs
+++ b/Test/Assets/Scripts/NoBulletEnemy.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using DefaultNamespace;
@@ -46,11 +47,41 @@ namespace Scripts
                 {
                     Vector3 pos = transform.position;
                     if (pos.x < 0)
+                    {
                         transform.position = new Vector3(8.5f, pos.y, pos.z);
+                    }
                     else
+                    {
                         transform.position = new Vector3(-8.5f, pos.y, pos.z);
+                    }
                 }
 
+            }
+        }
+
+        private void OnTriggerEnter(Collider collision)
+        {
+            //if (collision.gameObject.tag == "Attack")
+            //{
+            //    Debug.Log("当たった");
+            //    HP--;
+            //    damageText.ShowDamage(1);
+            //    audioSource.PlayOneShot(DamageSound);
+            //}
+
+            if (collision.gameObject.tag == "Bullet")
+            {
+                Debug.Log("当たった");
+                Bullet bullet = collision.gameObject.GetComponent<Bullet>();
+                HP -= bullet.Damage;
+                damageText.ShowDamage(bullet.Damage);
+                audioSource.PlayOneShot(DamageSound);
+            }
+
+            if (HP <= 0)
+            {
+                enemySpawn.RemoveEnemy(this.gameObject);
+                //Destroy(this.gameObject);
             }
         }
 

--- a/Test/Assets/Scripts/Player.cs
+++ b/Test/Assets/Scripts/Player.cs
@@ -17,7 +17,7 @@ namespace Scripts
         private PlayerInput MoveAction;
         private AudioSource audioSource;
         [NonSerialized] public Vector2 InputMove = Vector2.zero;
-        private Rigidbody2D rb;
+        private Rigidbody rb;
         private float startY;
         [SerializeField] MapManager mapManager;
         [SerializeField] SceneButtonManager sceneButtonManager;
@@ -39,7 +39,7 @@ namespace Scripts
         [JapaneseLabel("")]private bool isfirst = true;
         [JapaneseLabel("地面についているか")]private bool isGround;
         [JapaneseLabel("ジャンプ中か")]private bool isJump;
-        [JapaneseLabel("ジャンプ数")]private int jumpCount;
+        [SerializeField][JapaneseLabel("ジャンプ数")]private int jumpCount;
         [JapaneseLabel("最後にジャンプした時間")]private float lastJumpTime;
         [JapaneseLabel("攻撃中か")]public bool IsAttacking = false;
         [JapaneseLabel("発射中か")]private bool IsShot = false;
@@ -139,7 +139,7 @@ namespace Scripts
             MoveAction.actions["Aim"].canceled += OnQuickAttackAim;
 
             animator = GetComponent<Animator>();
-            rb = GetComponent<Rigidbody2D>();
+            rb = GetComponent<Rigidbody>();
             Arrow.SetActive(false);
             jumpCount = MaxJumpCount;
             audioSource = GetComponent<AudioSource>();
@@ -165,22 +165,32 @@ namespace Scripts
             {
                 currentShotStamina += overheatRecoveryPerSecond * Time.deltaTime;
             }
+            
+            Vector3 temp = transform.position;
+            temp.z = 0f;
             if (!isMove)
+            {
+                transform.position = temp;
                 return;
+            }
+            
             if (InputMove.x < 0)
             {
-                transform.position += new Vector3(MoveSpeed * InputMove.x, 0, 0) * Time.deltaTime;
+                temp+=new Vector3(MoveSpeed * InputMove.x, 0, 0) * Time.deltaTime;
+                //transform.position += new Vector3(MoveSpeed * InputMove.x, 0, 0) * Time.deltaTime;
                 transform.localScale = new Vector3(1f, 1f, -1f);
                 direction = -1;
             }
             else if (InputMove.x > 0)
             {
-                transform.position += new Vector3(MoveSpeed * InputMove.x, 0, 0) * Time.deltaTime;
+                temp+=new Vector3(MoveSpeed * InputMove.x, 0, 0) * Time.deltaTime;
+                //transform.position += new Vector3(MoveSpeed * InputMove.x, 0, 0) * Time.deltaTime;
                 transform.localScale = new Vector3(1f, 1f, 1f);
                 direction = 1;
             }
+            transform.position = temp;
 
-            animator.SetFloat("Jump", rb.linearVelocityY);
+            animator.SetFloat("Jump", rb.linearVelocity.magnitude);
             
             if (!IsAttacking && currentStamina < maxStamina)
             {

--- a/Test/Assets/Scripts/PlayerStatus.cs
+++ b/Test/Assets/Scripts/PlayerStatus.cs
@@ -27,7 +27,7 @@ namespace Scripts
         [JapaneseLabel("被弾時無敵時間")]
         private float invincibleDuration = 2.0f;
 
-        private readonly float checkDistance = 0.05f; // Raycastの長さ
+        private readonly float checkDistance = 0.08f; // Raycastの長さ
         private string enemyBulletTag = "EnemyBullet";
 
         private bool invincible;
@@ -76,7 +76,7 @@ namespace Scripts
         private void CheckGround()
         {
             isGrounded = false;
-            isGrounded = Physics2D.Raycast(groundCheck.position, Vector2.down, checkDistance, groundLayer);
+            isGrounded = Physics.Raycast(groundCheck.position, Vector2.down, checkDistance, groundLayer);
             if(!isGrounded) return;
                 
             animator.SetBool("isGround", isGrounded);

--- a/Test/Assets/Scripts/ReflectionWall.cs
+++ b/Test/Assets/Scripts/ReflectionWall.cs
@@ -5,6 +5,26 @@ namespace Scripts
 
     public class ReflectionWall : MonoBehaviour
     {
+        void OnTriggerEnter(Collider collider)
+        {
+            if (collider.TryGetComponent(out Bullet bullet))
+            {
+                Vector3 incomingPower = bullet.GetPower();
+                float speed = incomingPower.magnitude;
+
+                Vector3 normal = transform.up.normalized;
+
+                // Vector3.Reflectで反射ベクトルを求める
+                Vector3 reflectedDirection = Vector3.Reflect(incomingPower.normalized, normal);
+
+                // Bulletに新しい方向とスピードを設定
+                bullet.SetDirection(reflectedDirection);
+                bullet.SetSpeed(speed);
+                bullet.UpdatePower();
+
+                bullet.OnReflect();
+            }
+        }
         private void OnTriggerEnter2D(Collider2D collision)
         {
             if (collision.TryGetComponent(out Bullet bullet))

--- a/Test/Assets/Scripts/Shield.cs
+++ b/Test/Assets/Scripts/Shield.cs
@@ -1,3 +1,4 @@
+using System;
 using Scripts;
 using UnityEngine;
 
@@ -13,17 +14,37 @@ public class Shield : MonoBehaviour
 
     [SerializeField] private ShieldPosition shieldPosition;
     string playerBulletTag = "Bullet";
-    
-    // Start is called once before the first execution of Update after the MonoBehaviour is created
-    void Start()
-    {
-        
-    }
 
-    // Update is called once per frame
-    void Update()
+    private void OnTriggerEnter(Collider collision)
     {
-        
+        if (collision.CompareTag(playerBulletTag) == true)
+        {
+            Bullet bullet = collision.gameObject.GetComponent<Bullet>();
+            float speed = 0f;
+            //Debug.Log("ball:" + bullet.GetPower());
+            switch (shieldPosition)
+            {
+                case ShieldPosition.left:
+                    speed = bullet.GetPower().x;
+                    break;
+                case ShieldPosition.right:
+                    speed = bullet.GetPower().x * (-1);
+                    break;
+                case ShieldPosition.up:
+                    speed = bullet.GetPower().y * (-1);
+                    break;
+                case ShieldPosition.down:
+                    speed = bullet.GetPower().y;
+                    break;
+                default:
+                    break;
+            }
+
+            if (speed > 0)
+            {
+                Destroy(collision.gameObject);
+            }
+        }
     }
 
     private void OnTriggerEnter2D(Collider2D collision)

--- a/Test/Assets/Scripts/Warp.cs
+++ b/Test/Assets/Scripts/Warp.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -14,6 +15,17 @@ namespace Scripts
 
         private bool isWarping;
 
+        private void OnTriggerEnter(Collider other)
+        {
+            Debug.Log($"触れた: {other.tag}");
+            // タグがリストに含まれていて、現在ワープ中でないなら処理する
+            if (!isWarping && Tags.Contains(other.tag))
+            {
+                Debug.Log($"タグ一致、ワープ開始: {other.name}");
+                StartCoroutine(WarpPoint(other));
+            }
+        }
+
         private void OnTriggerEnter2D(Collider2D other)
         {
             Debug.Log($"触れた: {other.tag}");
@@ -25,6 +37,34 @@ namespace Scripts
             }
         }
 
+        private IEnumerator WarpPoint(Collider target)
+        {
+            isWarping = true;
+
+            var targetWarpPoint = targetWarp.GetComponent<Warp>();
+            if (targetWarpPoint != null) targetWarpPoint.isWarping = true;
+
+            // 親（ルート）ごと移動
+            var rootTransform = target.transform.root;
+
+            // CharacterController対策
+            var controller = rootTransform.GetComponent<CharacterController>();
+            if (controller != null)
+            {
+                controller.enabled = false;
+                rootTransform.position = targetWarp.position;
+                controller.enabled = true;
+            }
+            else
+            {
+                rootTransform.position = targetWarp.position;
+            }
+
+            yield return new WaitForSeconds(0.2f);
+
+            isWarping = false;
+            if (targetWarpPoint != null) targetWarpPoint.isWarping = false;
+        }
         private IEnumerator WarpPoint(Collider2D target)
         {
             isWarping = true;

--- a/Test/Assets/Scripts/WeakAttackReflector.cs
+++ b/Test/Assets/Scripts/WeakAttackReflector.cs
@@ -7,13 +7,43 @@ namespace Scripts
     {
         string playerBulletTag = "Bullet";
         [SerializeField,JapaneseLabel("〇以下の弱い弾を跳ね返す")] int destroyBulletCount = 1;
-        private Collider2D parentObjects;
+        private Collider parentObjects;
         
         private void Awake()
         {
-            parentObjects = transform.parent.GetComponent<Collider2D>();
+            parentObjects = transform.parent.GetComponent<Collider>();
             parentObjects.enabled = false;
         }
+
+        private void OnTriggerEnter(Collider collision)
+        {
+            if (collision.CompareTag(playerBulletTag))
+            {
+                Bullet bullet = collision.GetComponent<Bullet>();
+                int count = bullet.reflectionCount;
+
+                if (count <= destroyBulletCount)
+                {
+                    // 弱い弾は反射
+                    Vector3 originalPower = bullet.GetPower();
+                    Vector3 reversedDirection = -originalPower.normalized;
+                    float speed = originalPower.magnitude;
+
+                    bullet.SetDirection(reversedDirection);
+                    bullet.SetSpeed(speed);
+                    bullet.UpdatePower();
+
+                    bullet.OnReflect();
+                }
+                else
+                {
+                    // 強い弾は貫通 → 一時的に親のコライダーを有効にする
+                    parentObjects.enabled = true;
+                    Invoke(nameof(ParentCollider), 0.5f);
+                }
+            }
+        }
+
         private void OnTriggerEnter2D(Collider2D collision)
         {
             if (collision.CompareTag(playerBulletTag))


### PR DESCRIPTION
やったこと
・当たり判定の3D化
Player、Enemy、Bullet、EnemyBullet、Shield、Reflector、FloatArea、LoopArea、WarpのColliderを2Dから3Dに変更。及び、関連スクリプトのOnTriggerEnterも2Dから3Dに変更
3DColliderTestシーンで大体の敵は湧くようにしてるのでそこで確認お願いします。

PrefabにあったFloatAreaはColliderを3D化していますが、各Stageに置いてある足場等は3D化してないので確認後3D化してほしいです。