### PR TITLE
エネミーのテキストの角度修正

### DIFF
--- a/Test/Assets/Scripts/BackRotation.cs
+++ b/Test/Assets/Scripts/BackRotation.cs
@@ -6,19 +6,9 @@ namespace Scripts
 {
     public class BackRotation : MonoBehaviour
     {
-        private Vector3 def;
-
-        void Awake()
-        {
-            def = transform.localRotation.eulerAngles;
-            
-        }
-
         private void Update()
         {
-            Vector3 parent = transform.parent.transform.localRotation.eulerAngles;
-            
-            transform.localRotation = Quaternion.Euler(def - parent);
+            transform.eulerAngles = new Vector3(0, 0, 0);
         }
     }
 }


### PR DESCRIPTION
やったこと
・エネミーのダメージテキスト、攻撃前表示のテキストを常に同じ角度になるように修正