### PR TITLE
エネミーの出現を!からワープのエフェクトに置き換え

### DIFF
--- a/Test/Assets/Prefabs/Manager.prefab
+++ b/Test/Assets/Prefabs/Manager.prefab
@@ -599,6 +599,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 30166d86d9da2a945a7ba2dd3552b882, type: 2}
     - target: {fileID: 1960670821351675689, guid: 6b06abdb4225d6f4f8ef919ca26b48a1, type: 3}
+      propertyPath: warningTime
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 1960670821351675689, guid: 6b06abdb4225d6f4f8ef919ca26b48a1, type: 3}
       propertyPath: gameClearDelay
       value: 1
       objectReference: {fileID: 0}
@@ -609,7 +613,7 @@ PrefabInstance:
     - target: {fileID: 1960670821351675689, guid: 6b06abdb4225d6f4f8ef919ca26b48a1, type: 3}
       propertyPath: warningMarkerPrefab
       value: 
-      objectReference: {fileID: 4314835561913952412, guid: 3d4db0324e1021b46811bee65fb6b9ff, type: 3}
+      objectReference: {fileID: 3503430157411233234, guid: 2f7eedd62a7ed2e4ab5f6595beed0a39, type: 3}
     - target: {fileID: 1960670821351675689, guid: 6b06abdb4225d6f4f8ef919ca26b48a1, type: 3}
       propertyPath: remainingEnemiesText
       value: 

--- a/Test/Assets/Scripts/Enemy/EnemyAI.cs
+++ b/Test/Assets/Scripts/Enemy/EnemyAI.cs
@@ -93,43 +93,9 @@ public class EnemyAI : MonoBehaviour
     // Start is called once before the first execution of Update after the MonoBehaviour is created
     void Start()
     {
-        //hp = enemyData.maxHP;
         centerPos = this.transform.position;
         audioSource = GetComponent<AudioSource>();
         enemySpawnManager = EnemySpawnManager.Instance;
-
-        // //攻撃
-        // switch (enemyData.enemyAttackType)
-        // {
-        //     case EnemyData.EnemyAttackType.dontAttack:
-        //         break;
-        //     case EnemyData.EnemyAttackType.playerAim:
-        //         StartAttack();
-        //         break;
-        //     case EnemyData.EnemyAttackType.straight:
-        //         StartAttack();
-        //         break;
-        // }
-        //
-        // SetUp();
-        //
-        // switch (enemyData.enemyType)
-        // {
-        //     case EnemyData.EnemyType.boss:
-        //     case EnemyData.EnemyType.humanoid:
-        //         enemyHPSlider = GameObject.FindWithTag("EnemyHPBar").GetComponent<Slider>();
-        //         enemyHPSlider.maxValue = hp;
-        //         enemyHPSlider.value = hp;
-        //         break;
-        // }
-        //
-        // // 敵スポーンイベントをログ
-        // string enemyTypeStr = enemyData.enemyType.ToString();
-        // LudiscanManager.Instance.LogEnemySpawn(
-        //     enemyId: gameObject.name,
-        //     enemyType: enemyTypeStr,
-        //     position: transform.position
-        // );
     }
 
     // Update is called once per frame
@@ -185,11 +151,6 @@ public class EnemyAI : MonoBehaviour
                 HorizontalMove();
                 break;
         }
-    }
-
-    public void TestShow()
-    {
-        Debug.Log("EnemyAI:" + enemySpawnManager);
     }
     
     //移動
@@ -475,8 +436,7 @@ public class EnemyAI : MonoBehaviour
             enemyType: enemyTypeStr,
             position: transform.position
         );
-        
-        SetUp();
+        Invoke("SetUp", 0.05f);
     }
     public virtual void SetUp()
     {

--- a/Test/Assets/Scripts/Systems/EnemySpawnManager.cs
+++ b/Test/Assets/Scripts/Systems/EnemySpawnManager.cs
@@ -13,11 +13,14 @@ namespace Systems
 {
     public class EnemySpawnManager : MonoBehaviour
     {
-        [SerializeField] [JapaneseLabel("！マークのプレハブ")]
+        [SerializeField] [JapaneseLabel("出現エフェクトのプレハブ")]
         private GameObject warningMarkerPrefab;
+        
+        [SerializeField] [JapaneseLabel("全てのエネミーに出現エフェクトをつけるか")]
+        private bool allEnemyDirection = false;
 
-        [SerializeField] [JapaneseLabel("！マークを表示する時間（秒）")]
-        private float warningTime = 3f;
+        [SerializeField] [JapaneseLabel("出現エフェクトを表示する時間（秒）")]
+        private float warningTime = 4f;
 
         [SerializeField] [JapaneseLabel("敵を倒してからクリア演出までの時間")]
         private float gameClearDelay;
@@ -116,16 +119,30 @@ namespace Systems
                     enemyData.enemyId // Pass raw ID
                 ));
             }
+
+            Debug.Log("allEnemyDirection:" + allEnemyDirection);
         }
         private IEnumerator SpawnEnemyCoroutine(GameObject prefab, Transform spawnPoint, float spawnDelay, string instanceName,EnemyID excelEnemyID, string rawEnemyId)
         {
             var adjustedWarningTime = Mathf.Min(warningTime, spawnDelay);
-            if (adjustedWarningTime > 0)
+            if (adjustedWarningTime > 0 || allEnemyDirection == true)
             {
-                yield return new WaitForSeconds(spawnDelay - adjustedWarningTime);
+                float waitTime;
+                if (allEnemyDirection == true)
+                {
+                    adjustedWarningTime = warningTime;
+                    waitTime = 0f;
+                }
+                else
+                {
+                    waitTime = spawnDelay - adjustedWarningTime;
+                }
+
+                yield return new WaitForSeconds(waitTime);
                 var warningMarker = Instantiate(warningMarkerPrefab, spawnPoint.position,
                     warningMarkerPrefab.transform.rotation);
-                StartCoroutine(BlinkWarningMarker(warningMarker));
+                warningMarker.GetComponent<VisualEffect>().SendEvent("OnPlay");
+                //StartCoroutine(BlinkWarningMarker(warningMarker));
                 yield return new WaitForSeconds(adjustedWarningTime);
                 Destroy(warningMarker);
             }

--- a/Test/Assets/Scripts/Systems/EnemySpawnManager.cs
+++ b/Test/Assets/Scripts/Systems/EnemySpawnManager.cs
@@ -15,12 +15,12 @@ namespace Systems
     {
         [SerializeField] [JapaneseLabel("出現エフェクトのプレハブ")]
         private GameObject warningMarkerPrefab;
-        
-        [SerializeField] [JapaneseLabel("全てのエネミーに出現エフェクトをつけるか")]
-        private bool allEnemyDirection = false;
 
         [SerializeField] [JapaneseLabel("出現エフェクトを表示する時間（秒）")]
         private float warningTime = 4f;
+
+        [JapaneseLabel("エネミーを出現させる時間")]
+        private float enemySpawnTime = 3f;
 
         [SerializeField] [JapaneseLabel("敵を倒してからクリア演出までの時間")]
         private float gameClearDelay;
@@ -119,32 +119,19 @@ namespace Systems
                     enemyData.enemyId // Pass raw ID
                 ));
             }
-
-            Debug.Log("allEnemyDirection:" + allEnemyDirection);
         }
         private IEnumerator SpawnEnemyCoroutine(GameObject prefab, Transform spawnPoint, float spawnDelay, string instanceName,EnemyID excelEnemyID, string rawEnemyId)
         {
-            var adjustedWarningTime = Mathf.Min(warningTime, spawnDelay);
-            if (adjustedWarningTime > 0 || allEnemyDirection == true)
+            var adjustedWarningTime = Mathf.Min(enemySpawnTime, spawnDelay);
+            if (adjustedWarningTime > 0)
             {
-                float waitTime;
-                if (allEnemyDirection == true)
-                {
-                    adjustedWarningTime = warningTime;
-                    waitTime = 0f;
-                }
-                else
-                {
-                    waitTime = spawnDelay - adjustedWarningTime;
-                }
-
-                yield return new WaitForSeconds(waitTime);
+                yield return new WaitForSeconds(spawnDelay - adjustedWarningTime);
                 var warningMarker = Instantiate(warningMarkerPrefab, spawnPoint.position,
                     warningMarkerPrefab.transform.rotation);
                 warningMarker.GetComponent<VisualEffect>().SendEvent("OnPlay");
+                StartCoroutine(DestroyObjectCoroutine(warningMarker, warningTime));
                 //StartCoroutine(BlinkWarningMarker(warningMarker));
                 yield return new WaitForSeconds(adjustedWarningTime);
-                Destroy(warningMarker);
             }
             else
             {
@@ -175,6 +162,12 @@ namespace Systems
             }
         }
 
+        private IEnumerator DestroyObjectCoroutine(GameObject obj, float destroyTime)
+        {
+            yield return new WaitForSeconds(destroyTime);
+            
+            Destroy(obj);
+        }
         private IEnumerator BlinkWarningMarker(GameObject marker)
         {
             var markerRenderer = marker.GetComponent<Renderer>();

--- a/Test/Assets/Scripts/Systems/EnemySpawnManager.cs
+++ b/Test/Assets/Scripts/Systems/EnemySpawnManager.cs
@@ -125,8 +125,10 @@ namespace Systems
             var adjustedWarningTime = Mathf.Min(enemySpawnTime, spawnDelay);
             if (adjustedWarningTime > 0)
             {
+                Vector3 warpPos = spawnPoint.position;
+                warpPos.z += 0.2f;
                 yield return new WaitForSeconds(spawnDelay - adjustedWarningTime);
-                var warningMarker = Instantiate(warningMarkerPrefab, spawnPoint.position,
+                var warningMarker = Instantiate(warningMarkerPrefab, warpPos,
                     warningMarkerPrefab.transform.rotation);
                 warningMarker.GetComponent<VisualEffect>().SendEvent("OnPlay");
                 StartCoroutine(DestroyObjectCoroutine(warningMarker, warningTime));


### PR DESCRIPTION
やったこと
・エネミーの出現時の演出を!の点滅からワープのエフェクトに置き換え
(ワープの演出(lifetime？)が4秒で、今各シーンのenemySpawnManagerの各エネミーの出現するまでの時間(spawnDelay)がどのシーンも0秒のやつ以外が3秒になってるから、手間だけど修正した方がいいかも)