### PR TITLE
タイトルでポーズを開けないように

### DIFF
--- a/Test/Assets/Player.inputactions
+++ b/Test/Assets/Player.inputactions
@@ -340,6 +340,17 @@
                     "action": "Pause",
                     "isComposite": false,
                     "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "8183c4d2-ad96-4cfa-9a50-3a1fbb0c5a63",
+                    "path": "<Gamepad>/start",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Pause",
+                    "isComposite": false,
+                    "isPartOfComposite": false
                 }
             ]
         },

--- a/Test/Assets/Scripts/UI/SceneButtonManager.cs
+++ b/Test/Assets/Scripts/UI/SceneButtonManager.cs
@@ -217,7 +217,7 @@ namespace UI
     
         public void PauseGame()
         {
-            if (currentState == State.Clear || currentState == State.GameOver) { return; }
+            if (currentState == State.Clear || currentState == State.GameOver || currentState == State.Title) { return; }
         
             if (currentState != State.Pause)
             {


### PR DESCRIPTION
# やったこと
‐ タイトルでポーズを開けないように修正　
- コントローラのｓｔａｒｔボタンからポーズ画面を開けるように